### PR TITLE
Loosens dependency restrictions (#12)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ version = "0.3.0"
 status = "actively-developed"
 
 [dependencies]
-log = "~0.4"
-url = "~2.1"
+log = "^0.4"
+url = "^2.2"
 strum = "~0.18"
 strum_macros = "~0.18"
-anyhow = "~1.0"
-regex = "~1.3"
+anyhow = "^1.0"
+regex = "^1.4"
 
 [dev-dependencies]
-env_logger = "~0.7"
+env_logger = "^0.8"


### PR DESCRIPTION
Fixes #12 by switching from `~` version specifiers in `Cargo.toml` to `^`, except for `strum-macros` as it seems there were some breaking changes in recent versions.