### PR TITLE
[Merged by Bors] - Support Gerrit source code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,17 +238,23 @@ impl GitUrl {
                         }
                     }
                     false => {
-                        if splitpath.len() < 2 {
+                        if !url.starts_with("ssh") && splitpath.len() < 2 {
                             return Err(eyre!("git url is not of expected format"));
                         }
 
+                        let position = match splitpath.len() {
+                            0 => return Err(eyre!("git url is not of expected format")),
+                            1 => 0,
+                            _ => 1,
+                        };
+
                         // push owner
-                        fullname.push(splitpath[1]);
+                        fullname.push(splitpath[position]);
                         // push name
                         fullname.push(name.as_str());
 
                         (
-                            Some(splitpath[1].to_string()),
+                            Some(splitpath[position].to_string()),
                             None::<String>,
                             fullname.join("/"),
                         )

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -344,3 +344,25 @@ fn ssh_user_path_not_acctname_reponame_format() {
         "git url is not of expected format"
     );
 }
+
+#[test]
+fn ssh_without_owner() {
+    let test_url = "ssh://f589726c3611:29418/repo";
+    let parsed = GitUrl::parse(test_url).expect("URL parse failed");
+    let expected = GitUrl {
+        host: Some("f589726c3611".to_string()),
+        name: "repo".to_string(),
+        owner: Some("repo".to_string()),
+        organization: None,
+        fullname: "repo/repo".to_string(),
+        scheme: Scheme::Ssh,
+        user: None,
+        token: None,
+        port: Some(29418),
+        path: "repo".to_string(),
+        git_suffix: false,
+        scheme_prefix: true,
+    };
+
+    assert_eq!(parsed, expected);
+}

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -346,7 +346,7 @@ fn ssh_user_path_not_acctname_reponame_format() {
 }
 
 #[test]
-fn ssh_without_owner() {
+fn ssh_without_organization() {
     let test_url = "ssh://f589726c3611:29418/repo";
     let parsed = GitUrl::parse(test_url).expect("URL parse failed");
     let expected = GitUrl {


### PR DESCRIPTION
Hey, 
In [Gerrit](https://www.gerritcodereview.com/) source code there is no organization in the remote URL 

Gerrit repo remote origin URL:
```sh
git config --get remote.origin.url`
ssh://f589726c3611:29418/test-repo
```

in this case, when trying to parse the remote URL I get the error: `git url is not of expected format`.

## How to test it:
1. run Gerrit docker image:
```sh
docker run -ti -p 8080:8080 -p 29418:29418 gerritcodereview/gerrit
```
2. Create a repository
3. clone the repository
4. Run `GitUrl::parse` on the git remote URL
5. you should get an error, although the remote URL is valid in this case

## Fix
If the Git URL is not strat with `ssh`, keep the existing code behavior
if the code starts with `ssh` I'm taking the position like you have today from `splitpath`

added a test case to check this scenario, and all the existing test is pass successfully




