### PR TITLE
[Merged by Bors] - Add short git URL notation support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 use url::Url;
 
 /// Supported uri schemes for parsing
-#[derive(Debug, PartialEq, EnumString, EnumVariantNames, Clone, Display, Copy)]
+#[derive(Debug, PartialEq, Eq, EnumString, EnumVariantNames, Clone, Display, Copy)]
 #[strum(serialize_all = "kebab_case")]
 pub enum Scheme {
     /// Represents `file://` url scheme
@@ -36,7 +36,7 @@ pub enum Scheme {
 /// Internally during parsing the url is sanitized and uses the `url` crate to perform
 /// the majority of the parsing effort, and with some extra handling to expose
 /// metadata used my many git hosting services
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct GitUrl {
     /// The fully qualified domain name (FQDN) or IP of the repo
     pub host: Option<String>,
@@ -132,6 +132,14 @@ impl Default for GitUrl {
             git_suffix: false,
             scheme_prefix: false,
         }
+    }
+}
+
+impl FromStr for GitUrl {
+    type Err = color_eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        GitUrl::parse(s)
     }
 }
 

--- a/tests/normalize.rs
+++ b/tests/normalize.rs
@@ -10,6 +10,14 @@ fn git() {
 }
 
 #[test]
+fn git2() {
+    let test_url = "git:host.tld/user/project-name.git";
+    let normalized = normalize_url(test_url).expect("Normalizing url failed");
+
+    assert_eq!(normalized.as_str(), "git://host.tld/user/project-name.git");
+}
+
+#[test]
 fn http() {
     let test_url = "http://host.tld/user/project-name.git";
     let normalized = normalize_url(test_url).expect("Normalizing url failed");

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -366,3 +366,25 @@ fn ssh_without_organization() {
 
     assert_eq!(parsed, expected);
 }
+
+#[test]
+fn git() {
+    let test_url = "git:github.com/owner/name.git";
+    let parsed = GitUrl::parse(test_url).expect("URL parse failed");
+    let expected = GitUrl {
+        host: Some("github.com".to_string()),
+        name: "name".to_string(),
+        owner: Some("owner".to_string()),
+        organization: None,
+        fullname: "owner/name".to_string(),
+        scheme: Scheme::Git,
+        user: None,
+        token: None,
+        port: None,
+        path: "/owner/name.git".to_string(),
+        git_suffix: true,
+        scheme_prefix: true,
+    };
+
+    assert_eq!(parsed, expected);
+}


### PR DESCRIPTION
Github uses shot git URL notation (eg. `git:github.com/tjtelan/git-url-parse-rs.git`) in its REST API responses.
This PR adds support for such notation.

Moreover, the `serde_with` crate provides an easy way to (de)serialize a typed field using [`DisplayFromStr`](https://docs.rs/serde_with/2.0.0/serde_with/struct.DisplayFromStr.html). It requires implementing the `Display` and `FromStr` traits.