### PR TITLE
[Merged by Bors] - ci: Work out ci string parsing

### DIFF
--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -45,7 +45,7 @@ jobs:
         id: pr
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
         run: |
-          echo ${{ toJSON(github.event.head_commit) }}
+          echo '${{ toJSON(github.event.head_commit) }}' | jq '.message'
 
 
           NUMBER=$( echo '${{ github.event.head_commit.message }}' | head -1 | tr -cd [:digit:] )

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -45,10 +45,14 @@ jobs:
         id: pr
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
         run: |
+          echo toJSON(${{ github.event.head_commit.message }})
+
+
           NUMBER=$( echo '${{ github.event.head_commit.message }}' | head -1 | tr -cd [:digit:] )
 
           echo "PR number is: $NUMBER"
           echo "::set-output name=number::$NUMBER"
+          exit 1
 
   get_pr_number:
     name: Get PR number from event

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -148,8 +148,8 @@ jobs:
           echo "::set-output name=number::$PR_NUMBER"
           echo "pr number is: $PR_NUMBER"
 
-          #echo "::set-output name=title::$PR_TITLE"
-          #echo "pr title is: $PR_TITLE"
+          echo "::set-output name=title::$PR_TITLE"
+          echo "pr title is: $PR_TITLE"
 
   # This isn't working as expected
   #bot-label-check:

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -45,7 +45,7 @@ jobs:
         id: pr
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
         run: |
-          echo toJSON(${{ github.event.head_commit.message }})
+          echo ${{ toJSON(github.event.head_commit) }}
 
 
           NUMBER=$( echo '${{ github.event.head_commit.message }}' | head -1 | tr -cd [:digit:] )

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -45,16 +45,12 @@ jobs:
         id: pr
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
         run: |
-          git log --format=%B -n 1 $GITHUB_SHA
           git log --format=%B -n 1 $GITHUB_SHA | head -1 | tee /tmp/commit_msg
-
-          cat /tmp/commit_msg
+          echo PR title: $(cat /tmp/commit_msg)
 
           NUMBER=$( cat /tmp/commit_msg | head -1 | tr -cd [:digit:] )
-
           echo "PR number is: $NUMBER"
           echo "::set-output name=number::$NUMBER"
-          exit 1
 
   get_pr_number:
     name: Get PR number from event

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -45,8 +45,7 @@ jobs:
         id: pr
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
         run: |
-          git log --format=%B -n 1 $GITHUB_SHA | head -1 | tee /tmp/commit_msg
-          echo PR title: $(cat /tmp/commit_msg)
+          git log --format=%B -n 1 $GITHUB_SHA | head -1 > /tmp/commit_msg
 
           NUMBER=$( cat /tmp/commit_msg | head -1 | tr -cd [:digit:] )
           echo "PR number is: $NUMBER"
@@ -132,7 +131,7 @@ jobs:
           # Might need to b64 encode titles, so they can avoid exec from print later on
           # The commit message can be multiple lines, but we only want the first one
 
-          git log --format=%B -n 1 $GITHUB_SHA | head -1 | base64 | tee /tmp/pr-title
+          git log --format=%B -n 1 $GITHUB_SHA | head -1 | base64 > /tmp/pr-title
           echo PR_TITLE="$(cat /tmp/pr-title)" >> $GITHUB_ENV
           echo PR_TITLE="$(cat /tmp/pr-title)"
 
@@ -149,7 +148,7 @@ jobs:
           echo "pr number is: $PR_NUMBER"
 
           echo "::set-output name=title::$PR_TITLE"
-          echo "pr title is: $PR_TITLE"
+          echo "b64 encoded pr title is: $PR_TITLE"
 
   # This isn't working as expected
   #bot-label-check:
@@ -325,7 +324,3 @@ jobs:
           sleep ${{ env.RESTART_PR_DELAY }}
           gh pr edit ${{ needs.get_pr_info.outputs.pr_number }} --add-label ${{ env.ADD_PR_LABELS }}
           printf "Updated changelog before staging build.\nbors r+" | gh pr comment ${{ needs.get_pr_info.outputs.pr_number }} --body-file -
-
-      # I don't want to accidentally merge while I'm testing
-      - name: Fail test intentionally
-        run: exit 1

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -125,13 +125,14 @@ jobs:
         if: github.event_name == 'push'
         run: |
           echo "PR_BRANCH='$(git rev-parse --abbrev-ref HEAD)'" >> $GITHUB_ENV
-          echo "PR_BRANCH='$(git rev-parse --abbrev-ref HEAD)'"
+          echo "PR_BRANCH=$(git rev-parse --abbrev-ref HEAD)"
           echo "PR_NUMBER='${{ needs.get_pr_number.outputs.pr_number }}'" >> $GITHUB_ENV
           echo "PR_NUMBER='${{ needs.get_pr_number.outputs.pr_number }}'"
 
+          # Might need to b64 encode titles, so they can avoid exec from print later on
           # The commit message can be multiple lines, but we only want the first one
-          echo '${{ github.event.head_commit.message }}' > /tmp/pr-title-tmp
-          cat /tmp/pr-title-tmp | head -1 > /tmp/pr-title
+
+          git log --format=%B -n 1 $GITHUB_SHA | head -1 | base64 | tee /tmp/pr-title-tmp
           echo PR_TITLE="$(cat /tmp/pr-title)" >> $GITHUB_ENV
           echo PR_TITLE="$(cat /tmp/pr-title)"
 
@@ -147,8 +148,8 @@ jobs:
           echo "::set-output name=number::$PR_NUMBER"
           echo "pr number is: $PR_NUMBER"
 
-          echo "::set-output name=title::$PR_TITLE"
-          echo "pr title is: $PR_TITLE"
+          #echo "::set-output name=title::$PR_TITLE"
+          #echo "pr title is: $PR_TITLE"
 
   # This isn't working as expected
   #bot-label-check:
@@ -190,14 +191,10 @@ jobs:
         run: |
           git checkout ${{ env.DEFAULT_BRANCH }}
 
-          if [[ ${{ github.event_name == 'pull_request' }}  = 'true' ]]; then
-            git commit --all --allow-empty -m "${{ needs.get_pr_info.outputs.pr_title }} (#${{ needs.get_pr_info.outputs.pr_number }})"
-          fi
+          # Write commit into file, so we don't have to
+          echo ${{ needs.get_pr_info.outputs.pr_title }} | base64 -d > /tmp/commit_title
 
-          if [[ ${{ github.event_name == 'push' }}  = 'true' ]]; then
-            git commit --all --allow-empty -m "${{ needs.get_pr_info.outputs.pr_title }}"
-          fi
-
+          git commit --all --allow-empty -F /tmp/commit_title
           git log -5
 
       - name: Generate a changelog

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -326,3 +326,7 @@ jobs:
           sleep ${{ env.RESTART_PR_DELAY }}
           gh pr edit ${{ needs.get_pr_info.outputs.pr_number }} --add-label ${{ env.ADD_PR_LABELS }}
           printf "Updated changelog before staging build.\nbors r+" | gh pr comment ${{ needs.get_pr_info.outputs.pr_number }} --body-file -
+
+      # I don't want to accidentally merge while I'm testing
+      - name: Fail test intentionally
+        run: exit 1

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -45,12 +45,11 @@ jobs:
         id: pr
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
         run: |
-          echo '${{ toJSON(github.event.head_commit) }}' | jq '.message' > /tmp/commit_msg
+          echo git log --format=%B -n 1 $GITHUB_SHA | head -1 > /tmp/commit_msg
 
-          echo "Printing output from jq"
           cat /tmp/commit_msg
 
-          #NUMBER=$( echo '${{ github.event.head_commit.message }}' | head -1 | tr -cd [:digit:] )
+          NUMBER=$( cat /tmp/commit_msg | head -1 | tr -cd [:digit:] )
 
           echo "PR number is: $NUMBER"
           echo "::set-output name=number::$NUMBER"

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -132,7 +132,7 @@ jobs:
           # Might need to b64 encode titles, so they can avoid exec from print later on
           # The commit message can be multiple lines, but we only want the first one
 
-          git log --format=%B -n 1 $GITHUB_SHA | head -1 | base64 | tee /tmp/pr-title-tmp
+          git log --format=%B -n 1 $GITHUB_SHA | head -1 | base64 | tee /tmp/pr-title
           echo PR_TITLE="$(cat /tmp/pr-title)" >> $GITHUB_ENV
           echo PR_TITLE="$(cat /tmp/pr-title)"
 

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -45,7 +45,8 @@ jobs:
         id: pr
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
         run: |
-          echo git log --format=%B -n 1 $GITHUB_SHA | head -1 > /tmp/commit_msg
+          git log --format=%B -n 1 $GITHUB_SHA
+          git log --format=%B -n 1 $GITHUB_SHA | head -1 | tee /tmp/commit_msg
 
           cat /tmp/commit_msg
 

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -45,10 +45,12 @@ jobs:
         id: pr
         if: github.event_name == 'push' && github.ref == 'refs/heads/staging'
         run: |
-          echo '${{ toJSON(github.event.head_commit) }}' | jq '.message'
+          echo '${{ toJSON(github.event.head_commit) }}' | jq '.message' > /tmp/commit_msg
 
+          echo "Printing output from jq"
+          cat /tmp/commit_msg
 
-          NUMBER=$( echo '${{ github.event.head_commit.message }}' | head -1 | tr -cd [:digit:] )
+          #NUMBER=$( echo '${{ github.event.head_commit.message }}' | head -1 | tr -cd [:digit:] )
 
           echo "PR number is: $NUMBER"
           echo "::set-output name=number::$NUMBER"

--- a/.github/workflows/update-repo-stuff.yml
+++ b/.github/workflows/update-repo-stuff.yml
@@ -59,8 +59,8 @@ jobs:
     outputs:
       pr_number: ${{ steps.pr.outputs.number }}
     steps:
-      #- name: Dump context
-      #  uses: crazy-max/ghaction-dump-context@v1.2.1
+      - name: Dump context
+        uses: crazy-max/ghaction-dump-context@v1.2.1
 
       - name: Print PR number
         id: pr
@@ -109,8 +109,8 @@ jobs:
         id: info
         uses: Brymastr/pr-info-action@v1
 
-      #- name: Dump context
-      #  uses: crazy-max/ghaction-dump-context@v1.2.1
+      - name: Dump context
+        uses: crazy-max/ghaction-dump-context@v1.2.1
 
       - name: Set outputs from pull request event
         if: github.event_name == 'pull_request'
@@ -181,8 +181,8 @@ jobs:
           git config user.name "${{ env.GIT_BOT_USERNAME }}"
           git config user.email "${{ env.GIT_BOT_EMAIL }}"
 
-      #- name: Dump context
-      #  uses: crazy-max/ghaction-dump-context@v1.2.1
+      - name: Dump context
+        uses: crazy-max/ghaction-dump-context@v1.2.1
 
       - name: Simulate PR merge for changelog updates
         run: |
@@ -277,8 +277,8 @@ jobs:
           token: ${{ steps.app.outputs.token }}
           fetch-depth: 0
 
-      #- name: Dump context
-      #  uses: crazy-max/ghaction-dump-context@v1.2.1
+      - name: Dump context
+        uses: crazy-max/ghaction-dump-context@v1.2.1
 
       - name: Checkout PR branch
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add MSRV badge ([#36](https://github.com/tjtelan/git-url-parse-rs/issues/36))
 - Add personal access token to checkout ([#41](https://github.com/tjtelan/git-url-parse-rs/issues/41))
 - Add pre-merge generated updates ([#42](https://github.com/tjtelan/git-url-parse-rs/issues/42))
+- Add support for wasm32-unknown-unknown compilation target ([#44](https://github.com/tjtelan/git-url-parse-rs/issues/44))
 
 ### Fixed
 
@@ -27,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Troubleshoot CI commit fail ([#39](https://github.com/tjtelan/git-url-parse-rs/issues/39))
 - Troubleshoot Post PR ([#40](https://github.com/tjtelan/git-url-parse-rs/issues/40))
-- Labels and MSRV tuning ([#47](https://github.com/tjtelan/git-url-parse-rs/issues/47))
+- Work out ci string parsing ([#48](https://github.com/tjtelan/git-url-parse-rs/issues/48))
 
 ## [0.4.2](https://github.com/tjtelan/git-url-parse-rs/tree/v0.4.2) - 2022-05-30
 


### PR DESCRIPTION
Last PR failed due to simple string issue/

Testing CI issues when we use single quotes in the commit message.

contraction: y'all
'single quotes'
"double quotes"
`backtics`