### PR TITLE
Enable default features for the url crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 tracing = { version = "0.1", optional = true }
-url = { version = "^2.2", default-features = false }
+url = { version = "2.2" }
 strum = { version = "^0.26", features = ["derive"] }
 thiserror = "^1.0"
 


### PR DESCRIPTION
In order to make the rust-url compatible with no_std, the crate needs to introduce a `std` feature and make it default. See https://github.com/servo/rust-url/pull/831.

To reduce impact, downstream libraries should leave url's default features enabled (no other features are currently `default`).