### PR TITLE
update examples to include bitbucket urls explicitly, bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ tracing = ["dep:tracing"]
 tracing = { version = "0.1", optional = true }
 url = { version = "2.2" }
 strum = { version = "^0.26", features = ["derive"] }
-thiserror = "^1.0"
+thiserror = "2.0.11"
 
 [dev-dependencies]
-env_logger = "^0.9"
+env_logger = "0.11.6"
 regex = "^1.10"

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -19,6 +19,8 @@ fn main() -> Result<(), GitUrlParseError> {
         "..\\test_repo",
         "git@ssh.dev.azure.com:v3/CompanyName/ProjectName/RepoName",
         "https://CompanyName@dev.azure.com/CompanyName/ProjectName/_git/RepoName",
+        "https://your_username@bitbucket.org/workspace_ID/repo_name.git",
+        "ssh://git@bitbucket.org/workspace_ID/repo_name.git",
     ];
 
     for test_url in test_vec {

--- a/examples/trim_auth.rs
+++ b/examples/trim_auth.rs
@@ -17,6 +17,8 @@ fn main() -> Result<(), GitUrlParseError> {
         "./path/to/repo.git",
         "git@ssh.dev.azure.com:v3/CompanyName/ProjectName/RepoName",
         "https://CompanyName@dev.azure.com/CompanyName/ProjectName/_git/RepoName",
+        "https://your_username@bitbucket.org/workspace_ID/repo_name.git",
+        "ssh://git@bitbucket.org/workspace_ID/repo_name.git"
     ];
 
     for test_url in test_vec {


### PR DESCRIPTION
This is a small pull request to add links to the examples to cover a pattern that wasn't explicitly included. 

I've also bumped the following dependencies:
* thiserror from 1.0 to 2.0.11
* env_logger from 0.9 to 0.11.6

