### PR TITLE
Remove debug print

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -325,7 +325,6 @@ impl<'url> GitUrl<'url> {
         #[cfg(feature = "url")]
         {
             // Since we don't fully implement any spec, we'll rely on the url crate
-            println!("{:#?}", self.url_compat_display());
             let _u = url::Url::parse(&self.url_compat_display())?;
         }
 


### PR DESCRIPTION
This `println!` prints the url to stdout when parsing the URL