### PR TITLE
Remove lifetime from GitUrl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //!     #[derive(Debug, Clone, PartialEq, Eq)]
 //!     struct CustomProvider;
 //!     
-//!     impl GitProvider<GitUrl<'_>, GitUrlParseError> for CustomProvider {
+//!     impl GitProvider<GitUrl, GitUrlParseError> for CustomProvider {
 //!         fn from_git_url(_url: &GitUrl) -> Result<Self, GitUrlParseError> {
 //!             // Your custom provider parsing here
 //!             Ok(Self)

--- a/tests/provider.rs
+++ b/tests/provider.rs
@@ -46,7 +46,7 @@ fn ssh_generic_git() {
 fn custom_provider() {
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct TestProvider;
-    impl GitProvider<GitUrl<'_>, GitUrlParseError> for TestProvider {
+    impl GitProvider<GitUrl, GitUrlParseError> for TestProvider {
         fn from_git_url(_url: &GitUrl) -> Result<Self, GitUrlParseError> {
             Ok(Self)
         }


### PR DESCRIPTION
Fixes #69

* Change the internal `&str` to `String`
* New `impl` to replace derived getters